### PR TITLE
Division fixes

### DIFF
--- a/modules/morningtoncrescent/morningtoncrescent.py
+++ b/modules/morningtoncrescent/morningtoncrescent.py
@@ -133,11 +133,11 @@ class MorningtonCrescentInterpreter(AbstractInterpreter):
 		
 		# integer division
 		elif station == "Cannon Street":
-			action = lambda a, b : "" if b == 0 else int(floor(b / a))
+			action = lambda a, b : "" if a == 0 else b // a
 
 		# remainder
 		elif station == "Preston Road":
-			action = lambda a, b : "" if b == 0 else b % a
+			action = lambda a, b : "" if a == 0 else b % a
 		
 		# max
 		elif station == "Bounds Green":


### PR DESCRIPTION
 - Cannon Street and Preston Road now test the divisor for being zero instead of the dividend
 - Cannon Street uses integer division, making it work for bignums properly