### PR TITLE
Clean up behavior for IO

### DIFF
--- a/esoterpret.py
+++ b/esoterpret.py
@@ -8,7 +8,7 @@ Repository: https://github.com/Padarom/Esoterpret
 
 """
 
-import argparse, os, sys, inspect
+import argparse, os, sys, inspect, io
 
 from esoterpret.language import Language
 from esoterpret.terminal import Color
@@ -25,12 +25,11 @@ def listLanguages():
 			except:
 				pass
 
-def useLanguage(language, code, initialization, extra_args):
+def useLanguage(language, code, stdin, extra_args):
 	try:
 		lang = Language(language)
 		extrakws, extrapos = parseExtra(extra_args, lang, language)
-		interpreter = lang.Class(code, initialization,
-					 *extrapos, **extrakws)
+		interpreter = lang.Class(code, stdin, *extrapos, **extrakws)
 		while not(interpreter.hasExecutionFinished()):
 			interpreter.nextInstruction()
 	except ImportError:
@@ -87,7 +86,9 @@ if __name__ == "__main__":
 	                    action="store_true")
 
 	parser.add_argument("-s", "--stdin",
-	                    help="stdin values")
+	                    help="stdin values",
+			    type=io.StringIO,
+			    default=sys.stdin)
 
 	exclusive = parser.add_mutually_exclusive_group(required=True)
 
@@ -113,10 +114,8 @@ if __name__ == "__main__":
 	else:
 		if arguments.script:
 			code = arguments.script.read()
-			initialization = ""
-			if arguments.stdin:
-				initialization = arguments.stdin
 			arguments.script.close()
-			useLanguage(arguments.language, code, initialization, extra)
+			useLanguage(arguments.language, code,
+			            arguments.stdin, extra)
 		else:
 			parser.error("no file to execute specified")

--- a/esoterpret/interpreter/baseclass.py
+++ b/esoterpret/interpreter/baseclass.py
@@ -1,12 +1,13 @@
+import sys
 from abc import ABCMeta, abstractmethod
-from sys import stdin
 
 class AbstractInterpreter(metaclass=ABCMeta):
 	InstructionPointer = 0
 	Code = None
 
-	def __init__(self, code, defaults = None):
+	def __init__(self, code, stdin):
 		self.Code = code
+		self.stdin = stdin or sys.stdin
 
 	def output(self, text, newline = True):
 		if newline:
@@ -16,9 +17,9 @@ class AbstractInterpreter(metaclass=ABCMeta):
 
 	def input(self, character = False):
 		if character:
-			return stdin.read(1)
+			return self.stdin.read(1)
 		else:
-			return stdin.readline()
+			return self.stdin.readline()
 
 	@abstractmethod
 	def nextInstruction(self): pass

--- a/modules/morningtoncrescent/morningtoncrescent.py
+++ b/modules/morningtoncrescent/morningtoncrescent.py
@@ -23,26 +23,28 @@ class MorningtonCrescentInterpreter(AbstractInterpreter):
 	Jumpstack   = []
 	StationValues = {}
 
-	Code = []
 	_verbose = False
 
-	def __init__(self, code, acc, verbose = False):
+	def __init__(self, code, stdin, verbose = False):
 		"""
 		Initialize a new interpreter.
 
 		Arguments:
 			code -- the code to execute as a string
-			acc -- initialization value for accumulator
+			stdin -- file-like object to read initial accumulator from
+			verbose -- whether to print out each step as it is executed
 		"""
+		newcode = []
 		for line in iter(code.splitlines()):
 			pattern = re.compile("^Take (.*) Line to ([^#]*?)[\t ]*(#.*)?$")
 
 			# Add only valid Lines to the code list, ignoring the rest.
 			if pattern.match(line):
-				self.Code.append(line)
+				newcode.append(line)
+		super().__init__(newcode, stdin)
 
 		self._verbose = verbose
-		self.Accumulator = acc
+		self.Accumulator = self.input()
 
 		# Initialize Station Values to their names
 		for station in Stations.keys():


### PR DESCRIPTION
-s/--stdin now has more consistent behavior (this has little effect on the Mornington Crescent interpreter, but makes writing interpreters for languages with explicit IO easier)