### PR TITLE
Remove boilerplate code in Mornington Crescent interpreter

### DIFF
--- a/modules/morningtoncrescent/morningtoncrescent.py
+++ b/modules/morningtoncrescent/morningtoncrescent.py
@@ -133,7 +133,7 @@ class MorningtonCrescentInterpreter(AbstractInterpreter):
         # Debug
         if self._verbose:
             print("[" + str(self.instruction_pointer) + "] " + code)
-            print("Before: %r (%r)" % (self.accumulator, self.station_values[destination])))
+            print("Before: %r (%r)" % (self.accumulator, self.station_values[destination]))
 
         self.execute_station(destination)
 

--- a/modules/morningtoncrescent/morningtoncrescent.py
+++ b/modules/morningtoncrescent/morningtoncrescent.py
@@ -7,8 +7,70 @@ More information: http://esolangs.org/wiki/Mornington_Crescent
 """
 
 import re
+from operator import and_,  inv
+
 from esoterpret.interpreter.baseclass import AbstractInterpreter
 from modules.morningtoncrescent.stations import stations, lines
+
+def cannon_street(a, b):
+    if type(a) == int and type(b) == int:
+        if a == 0:
+            return ""
+        return b // a
+    raise TypeError
+def preston_road(a, b):
+    if type(a) == int and type(b) == int:
+        if a == 0:
+            return ""
+        return b % a
+    return NotImplemented
+def paddington(a, b):
+    if type(a) != str:
+        return NotImplemented
+    return b + a
+def gunnersbury(a, b):
+    if isinstance(a, int):
+        a, b = b, a
+    if b < 0:
+        raise RuntimeError("Cannot be negative")
+    return a[:b]
+def mile_end(a, b):
+    if isinstance(a, int):
+        a, b = b, a
+    if b < 0:
+        raise RuntimeError("Cannot be negative")
+    return a[-b:]
+BINARY_STATIONS = {
+    "Upminster":int.__add__,
+    "Chalfont & Latimer":int.__mul__,
+    "Cannon Street": cannon_street,
+    "Preston Road": preston_road,
+    "Bounds Green": max,
+    "Manor House": lambda a, b : ~(a | b),
+    "Holland Park": and_,
+    "Turnham Green": int.__rrshift__,
+    "Stepney Green": int.__rlshift__,
+    "Paddington": paddington,
+    "Gunnersbury": gunnersbury,
+    "Mile End": mile_end
+}
+def charing_cross(accum):
+    if isinstance(accum, str):
+        if accum:
+            return ord(accum[0])
+        else:
+            return 0
+    else:
+        return chr(accum)
+UNARY_STATIONS = {
+    "Russell Square": lambda a:a**2,
+    "Notting Hill Gate": inv,
+    "Seven Sisters": lambda a:7,
+    "Charing Cross": charing_cross,
+    "Upney": str.upper,
+    "Hounslow Central": str.lower,
+    "Turnpike Lane": lambda s:s[::-1],
+}
 
 class MorningtonCrescentInterpreter(AbstractInterpreter):
     """
@@ -49,6 +111,13 @@ class MorningtonCrescentInterpreter(AbstractInterpreter):
         elif self.instruction_pointer >= len(self.code):
             raise RuntimeError("You have to end at Mornington Crescent.")
 
+    @property
+    def current_value(self):
+        return self.station_values[self.location]
+    @current_value.setter
+    def current_value(self, value):
+        self.station_values[self.location] = value
+ 
     def next_instruction(self):
         """Execute the next instruction as specified by InstructionPointer"""
 
@@ -63,15 +132,15 @@ class MorningtonCrescentInterpreter(AbstractInterpreter):
 
         # Debug
         if self._verbose:
-            print ("[" + str(self.instruction_pointer) + "] " + code)
-            print ("Before: %s (%s)" % (repr(self.accumulator), repr(self.station_values[destination])))
+            print("[" + str(self.instruction_pointer) + "] " + code)
+            print("Before: %r (%r)" % (self.accumulator, self.station_values[destination])))
 
         self.execute_station(destination)
 
         # Debug
         if self._verbose:
-            print ("After:  %s (%s)" % (repr(self.accumulator), repr(self.station_values[self.location])))
-            print ("")
+            print("After:  %r (%r)" % (self.accumulator, self.current_value))
+            print()
 
         self.instruction_pointer += 1
 
@@ -92,7 +161,6 @@ class MorningtonCrescentInterpreter(AbstractInterpreter):
             raise RuntimeError("Station " + self.location + " doesn't have access to " + line + " Line.")
         elif line not in stations[destination]:
             raise RuntimeError("Station " + destination + " doesn't have access to " + line + " Line.")
-
     def execute_station(self, station):
         """
         Executes the destination station's instruction
@@ -102,193 +170,58 @@ class MorningtonCrescentInterpreter(AbstractInterpreter):
         """
         self.location = station
 
-        action = None
-        performDefault = False
-
-        # add
-        if station == "Upminster":
-            action = lambda a, b : a + b
-
-        # multiplier
-        elif station == "Chalfont & Latimer":
-            action = lambda a, b : a * b
-        
-        # integer division
-        elif station == "Cannon Street":
-            action = lambda a, b : "" if a == 0 else b // a
-
-        # remainder
-        elif station == "Preston Road":
-            action = lambda a, b : "" if a == 0 else b % a
-        
-        # max
-        elif station == "Bounds Green":
-            action = lambda a, b : max(a, b)
-        
-        # bitwise NOR
-        elif station == "Manor House":
-            action = lambda a, b : ~(a | b)
-
-        # bitwise AND
-        elif station == "Holland Park":
-            action = lambda a, b : a & b
-
-        # bitwise Shift-Right
-        elif station == "Turnham Green":
-            action = lambda a, b : b if a == 0 else b >> a
-
-        # bitwise Shift-Left
-        elif station == "Stepney Green":
-            action = lambda a, b : b if a == 0 else b << a
-
-        # square
-        elif station == "Russell Square":
-            if isinstance(self.station_values[station], int):
-                self.accumulator, self.station_values[station] = self.station_values[station] ** 2, self.accumulator
-            else:
-                performDefault = True
-
-        # bitwise NOT
-        elif station == "Notting Hill Gate":
-            if isinstance(self.station_values[station], int):
-                self.accumulator, self.station_values[station] = ~self.station_values[station], self.accumulator
-            else:
-                performDefault = True
-
+        # Check special stations that aren't implemented above
         # parse string to integer
-        elif station == "Parsons Green":
-            if isinstance(self.accumulator, str):
-                match = re.search("-?\d+", self.accumulator)
-                new_value = 0 if not(match) else self.accumulator[match.end():]
-                self.accumulator = 0 if not(match) else int(match.group())
-                self.station_values[station] = "" if not(match) else new_value
-            else:
-                performDefault = True
-
-        # 7
-        elif station == "Seven Sisters":
-            self.accumulator = 7
-
-        # character <> codepoint
-        elif station == "Charing Cross":
-            acc = self.accumulator
-            if isinstance(self.station_values[station], str):
-                self.accumulator = ord(self.station_values[station][0]) if self.station_values[station] else 0
-            else:
-                self.accumulator = chr(self.station_values[station])
-
-            self.station_values[station] = acc
-
-        # string concatenation
-        elif station == "Paddington":
-            acc = self.accumulator
-            if isinstance(self.station_values[station], str) and isinstance(self.accumulator, str):
-                self.accumulator = self.station_values[station] + self.accumulator
-                self.station_values[station] = acc
-            else:
-                performDefault = True
-
-        # left substring
-        elif station == "Gunnersbury":
-            acc = self.accumulator
-            if type(self.station_values[station]) == type(self.accumulator):
-                performDefault = True
-            elif isinstance(self.station_values[station], str):
-                if self.accumulator < 0:
-                    raise RuntimeError("Cannot be negative.")
-                
-                self.accumulator = self.station_values[station][:self.accumulator]
-                self.station_values[station] = acc
-
-            else:
-                if self.station_values[station] < 0:
-                    raise RuntimeError("Cannot be negative.")
-
-                self.accumulator = self.accumulator[:self.station_values[station]]
-                self.station_values[station] = acc
-
-        # right substring
-        elif station == "Mile End":
-            acc = self.accumulator
-            if type(self.station_values[station]) == type(self.accumulator):
-                performDefault = True
-            elif isinstance(self.station_values[station], str):
-                if self.accumulator < 0:
-                    raise RuntimeError("Cannot be negative.")
-
-                self.accumulator = self.station_values[station][-self.accumulator:]
-                self.station_values[station] = acc
-
-            else:
-                if self.station_values[station] < 0:
-                    raise RuntimeError("Cannot be negative.")
-
-                self.accumulator = self.accumulator[-self.station_values[station]:]
-                self.station_values[station] = acc
-
-        # upper-case
-        elif station == "Upney":
-            acc = self.accumulator
-            if isinstance(self.station_values[station], str):
-                self.accumulator = self.station_values[station].upper()
-                self.station_values[station] = acc
-            else:
-                performDefault = True
-
-        # lower-case
-        elif station == "Hounslow Central":
-            acc = self.accumulator
-            if isinstance(self.station_values[station], str):
-                self.accumulator = self.station_values[station].lower()
-                self.station_values[station] = acc
-            else:
-                performDefault = True
-
-        # reverse string
-        elif station == "Turnpike Lane":
-            acc = self.accumulator
-            if isinstance(self.station_values[station], str):
-                self.accumulator = self.station_values[station][::-1]
-            else:
-                performDefault = True
-
+        if station == "Parsons Green" and isinstance(self.accumulator, str):
+            match = re.search("-?\d+", self.accumulator)
+            new_value = 0 if not(match) else self.accumulator[match.end():]
+            self.accumulator = 0 if not(match) else int(match.group())
+            self.current_value = "" if not(match) else new_value
+            return
         # store
         elif station == "Bank":
             # Set Hammersmith to the same value
             self.station_values["Hammersmith"] = self.accumulator
-            performDefault = True
 
         # retain
         elif station == "Hammersmith":
-            self.accumulator = self.station_values[station]
+            self.accumulator = self.current_value
+            return
 
         # continuation
         elif station == "Temple":
             self.jumpstack.append(self.instruction_pointer)
+            return
 
         # if
         elif station == "Angel":
             if self.accumulator != 0:
                 self.location = "Temple"
                 self.instruction_pointer = self.jumpstack[-1]
+            return
 
         # pop
         elif station == "Marble Arch":
             del self.jumpstack[-1]
+            return
 
         # output/exit
         elif station == "Mornington Crescent":
             self.output(self.accumulator)
 
-        else:
-            performDefault = True
-
-        if action is not None:
-            if isinstance(self.accumulator, int) and isinstance(self.station_values[station], int):
-                acc = self.accumulator
-                self.accumulator = action(acc, self.station_values[station])
-                self.station_values[station] = acc
-            else:
-                performDefault = True
-        if performDefault:
-            self.accumulator, self.station_values[station] = self.station_values[station], self.accumulator
+        if station in UNARY_STATIONS:
+            try:
+                value = UNARY_STATIONS[station](self.current_value)
+                if value != NotImplemented:
+                    self.current_value = value
+            except TypeError:
+                pass
+        elif station in BINARY_STATIONS:
+            try:
+                func = BINARY_STATIONS[station]
+                value = func(self.accumulator, self.current_value)
+                if value != NotImplemented:
+                    self.current_value = value
+            except TypeError:
+                pass
+        self.accumulator, self.current_value = self.current_value, self.accumulator


### PR DESCRIPTION
Stations no longer need to handle low-level details like manipulating
the accumulator and their current value, and are instead implemented as functions.