### PR TITLE
Store acc value in Turnpike Lane after reversal

### DIFF
--- a/modules/morningtoncrescent/morningtoncrescent.py
+++ b/modules/morningtoncrescent/morningtoncrescent.py
@@ -249,6 +249,7 @@ class MorningtonCrescentInterpreter(AbstractInterpreter):
             acc = self.accumulator
             if isinstance(self.station_values[station], str):
                 self.accumulator = self.station_values[station][::-1]
+                self.station_values[station] = acc
             else:
                 performDefault = True
 


### PR DESCRIPTION
The interpreter behaviour is currently not equivalent to swapping the accumulator and station value before performing the string reversal. This means that the station does not perform its intended task, but instead always sets the accumulator to "enaL ekipnruT". 

This PR fixes this issue. Turnpike Lane now behaves similarly to Upney , which is consistent with [the esolang description](https://esolangs.org/wiki/Mornington_Crescent) and the [language author's implementation](https://github.com/Timwi/EsotericIDE).